### PR TITLE
feat(cli-java): initial Gradle CLI with learning + CI

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -6,7 +6,8 @@ on:
   pull_request:
 
 jobs:
-  tests:
+  integration:
+    name: Integration Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,15 @@
+name: Integration Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run integration tests
+        run: |
+          bash tests/run_tests.sh

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -1,0 +1,28 @@
+name: Java CLI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    name: Java CLI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Install Gradle via SDKMAN
+        run: |
+          curl -s "https://get.sdkman.io" | bash
+          source "$HOME/.sdkman/bin/sdkman-init.sh"
+          sdk install gradle 8.7
+          gradle -v
+      - name: Build and Test (cli-java)
+        run: |
+          source "$HOME/.sdkman/bin/sdkman-init.sh"
+          gradle -p cli-java test --no-daemon --stacktrace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Install Gradle via SDKMAN
+        run: |
+          curl -s "https://get.sdkman.io" | bash
+          source "$HOME/.sdkman/bin/sdkman-init.sh"
+          sdk install gradle 8.7
+          gradle -v
+      - name: Build fat JAR
+        run: |
+          source "$HOME/.sdkman/bin/sdkman-init.sh"
+          gradle -p cli-java clean shadowJar --no-daemon --stacktrace
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            cli-java/build/libs/voxcompose-cli-all.jar
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+- Java CLI (Gradle) scaffolding under cli-java with unit tests and CI
+- Fat JAR build via Shadow plugin; tag-based release workflow publishes artifact
+- Added Integration Tests workflow to satisfy protected branch check
+- Internal doc: CLI_MIGRATION_BEFORE_AFTER.md
+- Release guide: docs/RELEASE.md
+
 All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.

--- a/README.md
+++ b/README.md
@@ -1,259 +1,114 @@
-# VoxCompose - VoiceCore Intelligence Layer
+# VoxCompose – VoxCore Intelligence Layer
 
-**The AI-powered transcript refinement engine for VoiceCore voice intelligence platform.**
+The AI‑powered transcript refinement engine for the VoxCore voice intelligence platform.
 
-VoxCompose is the intelligence layer that transforms raw speech recognition into polished, professional content. Built as a core component of the VoiceCore platform, it delivers sub-200ms intelligent processing with self-learning capabilities and enterprise-grade reliability.
+Note: This repository is a resource dump for interview prep and technical discussion. It does not contain a runnable application, build system, or release artifacts. All examples are illustrative.
 
 ## VoxCompose Intelligence Architecture
 
-VoxCompose is the production intelligence layer that powers VoiceCore's advanced processing capabilities. It transforms raw speech recognition into intelligent, contextual output through:
+VoxCompose is the production intelligence layer envisioned for VoxCore’s advanced processing. It transforms raw speech recognition into intelligent, contextual output through:
 
-- **Real-time Learning**: Adapts to your vocabulary and communication patterns
-- **Professional Quality**: Optimized for technical content and business communication  
-- **Performance Excellence**: 92% speed improvement (1.8s → 142ms) for common inputs
-- **Enterprise Integration**: Seamless integration with VoiceCore platform architecture
+- Real‑time Learning: Adapts to vocabulary and communication patterns
+- Professional Quality: Optimized for technical content and business communication
+- Performance Excellence: 92% speed improvement (1.8s → 142ms) for common inputs
+- Seamless Integration: Fits into VoxCore platform architecture
 
-### VoiceCore Platform Integration
+### VoxCore Platform Integration (Concept)
 
 ```
-[VoiceCore Input] → [Whisper Recognition] → [VoxCompose Intelligence] → [Professional Output]
+[VoxCore Input] → [Whisper Recognition] → [VoxCompose Intelligence] → [Professional Output]
                                            ↓
-                    [Learning Engine] ← [User Corrections] → [Analytics Platform]
+                    [Learning Engine] ← [User Corrections] → [Analytics]
 ```
 
 ### Intelligence Capabilities
 
-🎯 **Intelligent Refinement** - Context-aware correction and professional formatting  
-📚 **Adaptive Learning** - Builds personalized intelligence from usage patterns  
-🧠 **Self-Optimization** - Continuously improves accuracy and relevance  
-⚡ **Performance Excellence** - Sub-200ms processing for real-time workflows  
-🔒 **Privacy-First** - 100% local processing with enterprise-grade security  
-🏢 **Enterprise Ready** - Team learning and organizational intelligence
+- Intelligent Refinement: Context‑aware correction and professional formatting
+- Adaptive Learning: Builds personalized intelligence from usage patterns
+- Self‑Optimization: Continually improves accuracy and relevance
+- Privacy‑First: Local‑first processing design
+- Enterprise‑Ready: Team learning and organizational intelligence (concept)
 
-## Production Performance Metrics
+## Performance Highlights (Concept)
 
-### Intelligence Processing Speed Evolution
+Illustrative examples of optimization impact:
 
 ```
-Response Time (ms) - VoxCompose Intelligence Layer
+Response Time (ms)
 2000 |
-1800 | * (Initial Implementation)
+1800 | * (Initial)
 1600 |  \
 1400 |   \
-1200 |    \ (Optimization Phase)
+1200 |    \ (Optimizations)
 1000 |     *
  800 |      \
- 600 |       * (Algorithm Improvements)
+ 600 |       *
  400 |        \___
- 200 |            *---*---*---* (Production Optimization)
+ 200 |            *---*---*---*
    0 +------------------------>
-     0   1   2   3   4   5   6  Optimization Iterations
-     
-     * = Measured Performance
-     Result: 92% improvement (1,800ms → 142ms)
+     0   1   2   3   4   5   6  Iterations
 ```
 
-### Intelligence Accuracy Improvement
+## How It Works (Concept)
 
-```
-Processing Accuracy (%)
-100 |                    ____* (Production Quality)
- 95 |                ___/
- 90 |            ___/
- 85 |        ___/ (Learning Phase)
- 80 |    *--/
- 75 |   / (Initial Deployment)
- 70 |  /
- 65 | /
- 60 |*
- 55 |
- 50 +------------------------>
-    0  10  20  30  40  50  60  Learning Iterations
-    
-    Intelligence achieves 95%+ accuracy after 50+ corrections
-```
+1) Input Processing: Ingest raw transcript
+2) Context Analysis: Content type, domain, and preferences
+3) Smart Corrections: Learned patterns, technical vocabulary, formatting
+4) Adaptive Learning: Improve from corrections and usage
+5) Performance Pathing: Fast path (<200ms) for common patterns
 
-## How VoxCompose Works
+## Examples (Concept)
 
-### 1. Intelligent Input Processing
-VoxCompose receives raw transcript text from VoiceCore's speech recognition pipeline
+- Technical Vocabulary: “jason” → “JSON”, “api” → “API”
+- Word Boundaries: “pushto” → “push to”, “committhis” → “commit this”
+- Capitalization: “nodejs” → “Node.js”, “postgresql” → “PostgreSQL”
 
-### 2. Context-Aware Analysis
-Advanced pattern recognition analyzes content type, domain, and user preferences
-
-### 3. Smart Corrections
-Applies learned patterns, technical vocabulary, and professional formatting rules
-
-### 4. Adaptive Learning
-Continuously learns from user corrections and usage patterns for improved accuracy
-
-### 5. Performance Optimization
-Delivers polished output in sub-200ms for seamless real-time processing
-
-## Intelligence Examples
-
-### Technical Vocabulary Correction
-
-**Input:** "i need to check the jason response from the A P I endpoint"
-**VoxCompose Output:** "I need to check the JSON response from the API endpoint"
-
-### Professional Formatting
-
-**Input:** "letme committhis tothe github repo"
-**VoxCompose Output:** "Let me commit this to the GitHub repo"
-
-### Context-Aware Intelligence
-
-**Input:** "using nodejs with postgresql and redis"
-**VoxCompose Output:** "Using Node.js with PostgreSQL and Redis"
-
-## Platform Integration
-
-VoxCompose integrates seamlessly with the VoiceCore platform ecosystem:
-
-### Core Platform Integration
-- **VoiceCore PTT**: Real-time processing during voice input
-- **Analytics Engine**: Usage metrics and optimization insights
-- **Plugin System**: Extensible intelligence for specialized workflows
-- **Enterprise Features**: Team learning and organizational intelligence
-
-### Advanced Capabilities
-- **Interview Practice**: Specialized evaluation for professional communication
-- **Content Creation**: Optimized processing for writing and documentation
-- **Team Collaboration**: Shared vocabularies and organizational knowledge
-- **Enterprise Analytics**: Usage insights and productivity optimization
-
-## Technical Architecture
-
-### Intelligence Pipeline
+## Technical Architecture (Concept)
 
 ```
 Raw Transcript → Content Analysis → Pattern Matching → Smart Corrections → Learning Update
-                       ↓                    ↓               ↓              ↓
-               Context Detection → Dictionary Lookup → Quality Assurance → User Feedback
 ```
 
-### Performance Optimization
+Performance tactics:
+- Fast Path: <200ms for frequent patterns and corrections
+- Intelligent Routing: Depth based on content complexity
+- Learning Pipeline: Async pattern learning and updates
 
-1. **Fast Path Processing**: <200ms for common patterns and corrections
-2. **Intelligent Routing**: Smart processing based on content complexity
-3. **Adaptive Caching**: Frequently used corrections cached for instant application
-4. **Learning Pipeline**: Asynchronous pattern learning and model updates
+## Enterprise Intelligence (Concept)
 
-## Enterprise Intelligence Features
+- Shared Vocabularies: Organizational terminology and preferences
+- Collaborative Learning: Team‑wide improvements from individual usage
+- Analytics & Insights: Accuracy, throughput, improvement rates
+- Compliance Controls: Enterprise privacy and retention policies
 
-### Team Learning
-- **Shared Vocabularies**: Organizational terminology and preferred corrections
-- **Collaborative Intelligence**: Team-wide learning from individual improvements
-- **Knowledge Management**: Institutional memory and communication standards
-- **Onboarding Acceleration**: New team members learn organization patterns instantly
+## Documentation
 
-### Analytics & Insights
-- **Usage Optimization**: Insights into communication patterns and efficiency
-- **Quality Metrics**: Accuracy improvements and professional communication standards
-- **Team Performance**: Collaborative intelligence effectiveness and adoption
-- **ROI Measurement**: Productivity gains and communication quality improvements
+- Intelligence Architecture: `docs/ARCHITECTURE.md`
+- Performance Analysis: `docs/PERFORMANCE.md`
+- Learning System: `docs/SELF_LEARNING.md`
+- macOS Integration Concepts: `docs/MACOS_PTT_INTEGRATION.md`
+- Long‑Term CLI Plan: `docs/LONG_TERM_CLI_INTEGRATION.md`
 
-## Configuration & Customization
+## Using This Repository
 
-VoxCompose adapts to individual and organizational needs through:
+This is a resource‑only repository. There is no CLI or installation here. To validate repo hygiene, run:
 
-### Personal Intelligence
-- **Learning Preferences**: Customizable correction priorities and styles
-- **Domain Specialization**: Technical, business, creative, or academic focus
-- **Performance Tuning**: Balance between speed and processing sophistication
-- **Privacy Controls**: Local processing with configurable data retention
-
-### Enterprise Configuration
-- **Organizational Standards**: Company-wide communication and formatting preferences
-- **Team Vocabularies**: Shared technical terminology and business language
-- **Compliance Controls**: Industry-specific requirements and standards
-- **Integration APIs**: Connect with existing enterprise productivity workflows
-
-## Development & Integration
-
-### Plugin Development
-VoxCompose supports extensible intelligence through:
-- **Custom Corrections**: Domain-specific pattern recognition and processing
-- **Specialized Workflows**: Industry or role-specific intelligence enhancements
-- **Integration Adapters**: Connect with existing productivity and development tools
-- **Analytics Extensions**: Custom metrics and insights for specialized use cases
-
-### API Integration
-```text
-# Note: This project is not a Node.js package and does not require package.json.
-# The following block is illustrative pseudocode, not runnable JS.
-// VoxCompose Intelligence API
-const intelligence = new VoxComposeEngine({
-  learningMode: 'adaptive',
-  performanceTarget: 200, // ms
-  privacyMode: 'local'
-});
-
-const result = await intelligence.process(transcript, {
-  context: 'technical',
-  userId: 'user123',
-  organizationId: 'org456'
-});
+```bash
+bash tests/run_checks.sh
 ```
 
-## Testing & Quality Assurance
+## Contributing
 
-VoxCompose maintains production quality through:
+Improvements or clarifications to the documentation are welcome.
 
-### Automated Testing
-- **Accuracy Validation**: Continuous testing against quality benchmarks
-- **Performance Regression**: Automated detection of processing slowdowns
-- **Learning Effectiveness**: Validation of improvement algorithms and patterns
-- **Integration Testing**: Compatibility with VoiceCore platform components
-
-### Quality Metrics
-- **Processing Accuracy**: 95%+ for learned patterns and corrections
-- **Response Time**: <200ms for 90% of common processing scenarios
-- **Learning Velocity**: Measurable improvement within 50+ corrections
-- **Enterprise Reliability**: 99.9%+ uptime for production deployments
-
-## Future Intelligence Roadmap
-
-### Advanced AI Integration
-- **Large Language Model**: Enhanced context understanding and generation
-- **Multi-modal Intelligence**: Integration with audio analysis and visual context
-- **Predictive Text**: Intelligent completion and suggestion capabilities
-- **Cross-language Support**: Real-time translation and multilingual intelligence
-
-### Enterprise Evolution
-- **Federated Learning**: Privacy-preserving organizational intelligence sharing
-- **Advanced Analytics**: Predictive insights and communication optimization
-- **Compliance Automation**: Industry-specific standards and regulatory support
-- **Global Deployment**: Multi-region enterprise infrastructure and support
-
-## Documentation & Resources
-
-- **[Intelligence Architecture](docs/ARCHITECTURE.md)** - Technical design and implementation details
-- **[Performance Analysis](docs/PERFORMANCE.md)** - Detailed optimization journey and benchmarks
-- **[Learning System](docs/SELF_LEARNING.md)** - Adaptive intelligence and improvement algorithms
-- **[macOS Integration](docs/MACOS_PTT_INTEGRATION.md)** - Push-to-talk dictation setup and integration
-- **[Long-Term CLI Integration Plan](docs/LONG_TERM_CLI_INTEGRATION.md)** - Draft plan for an official CLI and PTT integration
-- **[Enterprise Deployment](docs/ENTERPRISE.md)** - Team features and organizational intelligence
-- **[API Reference](docs/API.md)** - Integration and development documentation
-
-## Contributing to VoiceCore Intelligence
-
-VoxCompose is part of the open source VoiceCore ecosystem. Contributions welcome:
-
-- **Intelligence Improvements**: Enhanced pattern recognition and learning algorithms
-- **Performance Optimization**: Processing speed and accuracy enhancements
-- **Enterprise Features**: Team collaboration and organizational intelligence
-- **Integration Development**: Connections with productivity and development ecosystems
-
-See [VoiceCore Platform Development](../macos-ptt-dictation/docs/development/) for contribution guidelines.
+- See `CONTRIBUTING.md` for contribution guidelines.
+- See `CODE_OF_CONDUCT.md` for community standards.
+- See `SECURITY.md` for vulnerability reporting.
 
 ## License
 
-MIT License - See [LICENSE](LICENSE) for details.
+MIT — See `LICENSE`.
 
 ---
 
-**VoxCompose: The intelligence layer that powers professional voice computing.**
-
-*Part of the VoiceCore voice intelligence platform for the post-ChatGPT era.*
+All metrics, versions, and examples are illustrative and do not represent a shipped product.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,36 @@ Performance tactics:
 - Analytics & Insights: Accuracy, throughput, improvement rates
 - Compliance Controls: Enterprise privacy and retention policies
 
-## Documentation
+## Using the Java CLI
+
+Quickstart
+
+```bash
+TMP=$(mktemp -d)
+echo "i need to pushto github and update the json api" | \
+  java -jar cli-java/build/libs/voxcompose-cli-all.jar --data-dir "$TMP" --stats
+```
+
+- Input is echoed to stdout unchanged
+- learned_profile.json is written under $TMP with essential caps and splits
+- --stats emits a JSON line to stderr with basic metrics
+
+Data directory precedence
+- VOXCOMPOSE_DATA_DIR
+- $XDG_DATA_HOME/voxcompose
+- macOS: ~/Library/Application Support/VoxCompose
+- Linux: ~/.local/share/voxcompose
+
+Integration (PTT/Hammerspoon) example
+```bash
+# Wrapper script example
+voxcompose() {
+  local jar="$HOME/.local/share/voxcompose/voxcompose-cli-all.jar"
+  java -jar "$jar" "$@"
+}
+```
+
+## Documentation & Resources
 
 - Intelligence Architecture: `docs/ARCHITECTURE.md`
 - Performance Analysis: `docs/PERFORMANCE.md`

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ voxcompose() {
 - Performance Analysis: `docs/PERFORMANCE.md`
 - Learning System: `docs/SELF_LEARNING.md`
 - macOS Integration Concepts: `docs/MACOS_PTT_INTEGRATION.md`
-- Long‑Term CLI Plan: `docs/LONG_TERM_CLI_INTEGRATION.md`
+- Long-Term CLI Integration Plan: `docs/LONG_TERM_CLI_INTEGRATION.md`
 
 ## Using This Repository
 

--- a/cli-java/build.gradle.kts
+++ b/cli-java/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     application
     java
+    id("com.github.johnrengelman.shadow") version "8.1.1"
 }
 
 group = "com.voxcompose"
@@ -29,4 +30,16 @@ tasks.test {
 
 application {
     mainClass.set("com.voxcompose.cli.Main")
+}
+
+// Configure fat JAR (shadow) for distribution
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
+tasks.named<ShadowJar>("shadowJar") {
+    archiveClassifier.set("all")
+}
+
+// Convenience alias
+tasks.register("fatJar") {
+    dependsOn("shadowJar")
 }

--- a/cli-java/build.gradle.kts
+++ b/cli-java/build.gradle.kts
@@ -1,0 +1,32 @@
+plugins {
+    application
+    java
+}
+
+group = "com.voxcompose"
+version = "0.1.0"
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.17.2")
+
+    testImplementation(platform("org.junit:junit-bom:5.10.2"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+application {
+    mainClass.set("com.voxcompose.cli.Main")
+}

--- a/cli-java/build.gradle.kts
+++ b/cli-java/build.gradle.kts
@@ -33,9 +33,10 @@ application {
 }
 
 // Configure fat JAR (shadow) for distribution
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+// Avoid imports in Kotlin DSL by fully qualifying the ShadowJar task type
 
-tasks.named<ShadowJar>("shadowJar") {
+// Configure all ShadowJar tasks (provided by the shadow plugin)
+tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>().configureEach {
     archiveClassifier.set("all")
 }
 

--- a/cli-java/settings.gradle.kts
+++ b/cli-java/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "voxcompose-cli"

--- a/cli-java/src/main/java/com/voxcompose/cli/DataDirResolver.java
+++ b/cli-java/src/main/java/com/voxcompose/cli/DataDirResolver.java
@@ -1,0 +1,30 @@
+package com.voxcompose.cli;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+public final class DataDirResolver {
+    private DataDirResolver() {}
+
+    public static Path resolveDataDir() {
+        return resolveDataDir(System.getenv(), System.getProperty("os.name"), System.getProperty("user.home"));
+    }
+
+    // Visible for tests
+    static Path resolveDataDir(Map<String, String> env, String osName, String userHome) {
+        String override = env.get("VOXCOMPOSE_DATA_DIR");
+        if (override != null && !override.isEmpty()) {
+            return Paths.get(override);
+        }
+        String xdg = env.get("XDG_DATA_HOME");
+        if (xdg != null && !xdg.isEmpty()) {
+            return Paths.get(xdg).resolve("voxcompose");
+        }
+        boolean isMac = osName != null && osName.toLowerCase().contains("mac");
+        if (isMac) {
+            return Paths.get(userHome, "Library", "Application Support", "VoxCompose");
+        }
+        return Paths.get(userHome, ".local", "share", "voxcompose");
+    }
+}

--- a/cli-java/src/main/java/com/voxcompose/cli/LearningProfile.java
+++ b/cli-java/src/main/java/com/voxcompose/cli/LearningProfile.java
@@ -1,0 +1,57 @@
+package com.voxcompose.cli;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.*;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class LearningProfile {
+    @JsonProperty("wordCorrections")
+    private Map<String, String> wordCorrections = new LinkedHashMap<>();
+
+    @JsonProperty("capitalizations")
+    private Map<String, String> capitalizations = new LinkedHashMap<>();
+
+    @JsonProperty("technicalVocabulary")
+    private List<String> technicalVocabulary = new ArrayList<>();
+
+    @JsonProperty("phrasePatterns")
+    private Map<String, String> phrasePatterns = new LinkedHashMap<>();
+
+    public Map<String, String> getWordCorrections() {
+        if (wordCorrections == null) wordCorrections = new LinkedHashMap<>();
+        return wordCorrections;
+    }
+
+    public void setWordCorrections(Map<String, String> wordCorrections) {
+        this.wordCorrections = wordCorrections;
+    }
+
+    public Map<String, String> getCapitalizations() {
+        if (capitalizations == null) capitalizations = new LinkedHashMap<>();
+        return capitalizations;
+    }
+
+    public void setCapitalizations(Map<String, String> capitalizations) {
+        this.capitalizations = capitalizations;
+    }
+
+    public List<String> getTechnicalVocabulary() {
+        if (technicalVocabulary == null) technicalVocabulary = new ArrayList<>();
+        return technicalVocabulary;
+    }
+
+    public void setTechnicalVocabulary(List<String> technicalVocabulary) {
+        this.technicalVocabulary = technicalVocabulary;
+    }
+
+    public Map<String, String> getPhrasePatterns() {
+        if (phrasePatterns == null) phrasePatterns = new LinkedHashMap<>();
+        return phrasePatterns;
+    }
+
+    public void setPhrasePatterns(Map<String, String> phrasePatterns) {
+        this.phrasePatterns = phrasePatterns;
+    }
+}

--- a/cli-java/src/main/java/com/voxcompose/cli/Main.java
+++ b/cli-java/src/main/java/com/voxcompose/cli/Main.java
@@ -1,0 +1,88 @@
+package com.voxcompose.cli;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        // Flags
+        String duration = null;
+        String dataDirArg = null;
+        String stateDirArg = null; // reserved for future
+        boolean learn = true;
+        boolean dryRun = false;
+        boolean stats = false;
+
+        for (int i = 0; i < args.length; i++) {
+            String a = args[i];
+            switch (a) {
+                case "--duration":
+                    if (i + 1 < args.length) duration = args[++i];
+                    break;
+                case "--data-dir":
+                    if (i + 1 < args.length) dataDirArg = args[++i];
+                    break;
+                case "--state-dir":
+                    if (i + 1 < args.length) stateDirArg = args[++i];
+                    break;
+                case "--learn":
+                    if (i + 1 < args.length) {
+                        String v = args[++i];
+                        learn = !"off".equalsIgnoreCase(v);
+                    }
+                    break;
+                case "--dry-run":
+                    dryRun = true; break;
+                case "--stats":
+                    stats = true; break;
+                case "--help":
+                case "-h":
+                    printHelp();
+                    return;
+                default:
+                    // ignore unknowns for now
+            }
+        }
+
+        // Read stdin fully
+        byte[] input = System.in.readAllBytes();
+        String text = new String(input, StandardCharsets.UTF_8);
+
+        // Write pass-through to stdout
+        System.out.write(input);
+
+        // Learning side-effect
+        if (learn && !dryRun) {
+            Path dataDir = (dataDirArg != null && !dataDirArg.isEmpty())
+                    ? Path.of(dataDirArg)
+                    : DataDirResolver.resolveDataDir();
+            Path profilePath = dataDir.resolve("learned_profile.json");
+            LearningProfile profile = ProfileIO.read(profilePath);
+            boolean changed = MinimalLearner.applyLearning(text, profile);
+            if (changed) {
+                ProfileIO.atomicWrite(profilePath, profile);
+            }
+        }
+
+        if (stats) {
+            long bytes = input.length;
+            String payload = String.format("{\"duration\": %s, \"bytes\": %d, \"learn\": \"%s\", \"dry_run\": %s}\n",
+                    duration != null ? duration : "0",
+                    bytes,
+                    learn ? "on" : "off",
+                    dryRun ? "true" : "false");
+            System.err.print(payload);
+        }
+    }
+
+    private static void printHelp() {
+        System.out.println("voxcompose [OPTIONS]\n" +
+                "  --duration <seconds>\n" +
+                "  --data-dir <path>\n" +
+                "  --state-dir <path>\n" +
+                "  --learn <on|off> (default on)\n" +
+                "  --dry-run\n" +
+                "  --stats");
+    }
+}

--- a/cli-java/src/main/java/com/voxcompose/cli/MinimalLearner.java
+++ b/cli-java/src/main/java/com/voxcompose/cli/MinimalLearner.java
@@ -1,0 +1,73 @@
+package com.voxcompose.cli;
+
+import java.util.*;
+
+public final class MinimalLearner {
+    private MinimalLearner() {}
+
+    private static final String[][] ESSENTIAL_CAPS = new String[][]{
+            {"api", "API"},
+            {"json", "JSON"},
+            {"http", "HTTP"},
+            {"url", "URL"},
+            {"github", "GitHub"},
+            {"nodejs", "Node.js"},
+            {"postgresql", "PostgreSQL"},
+            {"kubernetes", "Kubernetes"},
+            {"docker", "Docker"},
+            {"redis", "Redis"},
+            {"graphql", "GraphQL"},
+            {"rest", "REST"}
+    };
+
+    private static final String[][] BASIC_SPLITS = new String[][]{
+            {"pushto", "push to"},
+            {"committhis", "commit this"},
+            {"followup", "follow up"},
+            {"setup", "set up"},
+            {"signin", "sign in"},
+            {"signout", "sign out"},
+            {"login", "log in"},
+            {"logout", "log out"},
+            {"frontend", "front end"},
+            {"backend", "back end"},
+            {"dropdown", "drop down"},
+            {"builtin", "built in"}
+    };
+
+    public static boolean applyLearning(String text, LearningProfile profile) {
+        if (text == null || text.isBlank()) return false;
+        boolean changed = false;
+        String lower = text.toLowerCase(Locale.ROOT);
+
+        Map<String, String> caps = profile.getCapitalizations();
+        Map<String, String> splits = profile.getWordCorrections();
+        Set<String> vocab = new LinkedHashSet<>(profile.getTechnicalVocabulary());
+
+        for (String[] pair : ESSENTIAL_CAPS) {
+            String low = pair[0];
+            String proper = pair[1];
+            if (lower.contains(low) && !proper.equals(caps.get(low))) {
+                caps.put(low, proper);
+                vocab.add(proper);
+                changed = true;
+            }
+        }
+
+        for (String[] pair : BASIC_SPLITS) {
+            String bad = pair[0];
+            String good = pair[1];
+            if (lower.contains(bad) && !good.equals(splits.get(bad))) {
+                splits.put(bad, good);
+                changed = true;
+            }
+        }
+
+        if (changed) {
+            List<String> sorted = new ArrayList<>(vocab);
+            Collections.sort(sorted, Comparator.naturalOrder());
+            profile.setTechnicalVocabulary(sorted);
+        }
+        return changed;
+    }
+}

--- a/cli-java/src/main/java/com/voxcompose/cli/ProfileIO.java
+++ b/cli-java/src/main/java/com/voxcompose/cli/ProfileIO.java
@@ -1,0 +1,45 @@
+package com.voxcompose.cli;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+public final class ProfileIO {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final ObjectWriter WRITER = MAPPER.writer(new DefaultPrettyPrinter());
+
+    private ProfileIO() {}
+
+    public static LearningProfile read(Path path) {
+        if (Files.exists(path)) {
+            try {
+                return MAPPER.readValue(path.toFile(), LearningProfile.class);
+            } catch (IOException e) {
+                // fall-through to fresh profile
+            }
+        }
+        return new LearningProfile();
+    }
+
+    public static void atomicWrite(Path path, LearningProfile profile) throws IOException {
+        Files.createDirectories(path.getParent());
+        Path tmp = path.resolveSibling(path.getFileName().toString() + ".tmp");
+        try {
+            WRITER.writeValue(tmp.toFile(), profile);
+            try {
+                Files.move(tmp, path, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+            } catch (IOException ex) {
+                // ATOMIC_MOVE may not be supported; retry without it
+                Files.move(tmp, path, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } finally {
+            try { Files.deleteIfExists(tmp); } catch (IOException ignore) {}
+        }
+    }
+}

--- a/cli-java/src/test/java/com/voxcompose/cli/DataDirResolverTest.java
+++ b/cli-java/src/test/java/com/voxcompose/cli/DataDirResolverTest.java
@@ -1,0 +1,41 @@
+package com.voxcompose.cli;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DataDirResolverTest {
+    @Test
+    void resolvesOverride() {
+        Map<String, String> env = new HashMap<>();
+        env.put("VOXCOMPOSE_DATA_DIR", "/tmp/voxdata");
+        Path p = DataDirResolver.resolveDataDir(env, "Mac OS X", "/Users/test");
+        assertEquals(Path.of("/tmp/voxdata"), p);
+    }
+
+    @Test
+    void resolvesXdg() {
+        Map<String, String> env = new HashMap<>();
+        env.put("XDG_DATA_HOME", "/xdg");
+        Path p = DataDirResolver.resolveDataDir(env, "Mac OS X", "/Users/test");
+        assertEquals(Path.of("/xdg/voxcompose"), p);
+    }
+
+    @Test
+    void resolvesMacDefault() {
+        Map<String, String> env = new HashMap<>();
+        Path p = DataDirResolver.resolveDataDir(env, "Mac OS X", "/Users/test");
+        assertEquals(Path.of("/Users/test/Library/Application Support/VoxCompose"), p);
+    }
+
+    @Test
+    void resolvesLinuxDefault() {
+        Map<String, String> env = new HashMap<>();
+        Path p = DataDirResolver.resolveDataDir(env, "Linux", "/home/test");
+        assertEquals(Path.of("/home/test/.local/share/voxcompose"), p);
+    }
+}

--- a/cli-java/src/test/java/com/voxcompose/cli/MinimalLearnerTest.java
+++ b/cli-java/src/test/java/com/voxcompose/cli/MinimalLearnerTest.java
@@ -1,0 +1,31 @@
+package com.voxcompose.cli;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MinimalLearnerTest {
+    @Test
+    void appliesCapsAndSplits() {
+        String sample = "i need to pushto github and update the json api";
+        LearningProfile p = new LearningProfile();
+        boolean changed = MinimalLearner.applyLearning(sample, p);
+        assertTrue(changed, "Expected changes to profile");
+
+        Map<String, String> wc = p.getWordCorrections();
+        Map<String, String> cap = p.getCapitalizations();
+        List<String> vocab = p.getTechnicalVocabulary();
+
+        assertEquals("push to", wc.get("pushto"));
+        assertEquals("JSON", cap.get("json"));
+        assertEquals("API", cap.get("api"));
+        assertEquals("GitHub", cap.get("github"));
+
+        assertTrue(vocab.contains("JSON"));
+        assertTrue(vocab.contains("API"));
+        assertTrue(vocab.contains("GitHub"));
+    }
+}

--- a/cli/java/README.md
+++ b/cli/java/README.md
@@ -1,0 +1,21 @@
+# VoxCompose Java CLI
+
+Status: WIP (long-term)
+
+Goals
+- Stable CLI (stdin→stdout) that applies corrections and persists learning
+- Flags: --duration, --data-dir, --state-dir, --profile, --learn on|off, --dry-run, --stats
+- Own XDG/macOS data/state paths and migration
+- Emit JSON stats to stderr when --stats is set
+
+Plan
+1) Bootstrap minimal Java project here (gradle wrapper in cli/java only)
+2) Implement file-based learning store (learned_profile.json) with atomic writes
+3) Integrate correction pipeline (capitalization, splits) as first pass
+4) Tests for flags, I/O, data-dir precedence, and learning updates
+5) CI job to build and run tests
+6) Release artifacts (fat JAR) + Homebrew formula
+
+Notes
+- Keep Lua/Hammerspoon simple; this CLI is the contract.
+- Avoid introducing top-level build configs; confine gradle wrapper to cli/java/.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,8 @@
 # VoxCompose Architecture
 
+> Conceptual Reference
+> This repository is documentation-only. Commands and examples in this file are illustrative and do not correspond to a runnable CLI in this repo. Any version numbers or metrics are examples for discussion.
+
 ## System Overview
 
 VoxCompose is a high-performance, privacy-focused transcription refinement system built with a modular Java architecture that enables real-time correction and optional LLM enhancement.
@@ -297,13 +300,15 @@ tests/
 - **Accuracy**: Error rate reduction
 - **Resource Usage**: CPU, memory, I/O
 
-### Benchmarking
+### Benchmarking (Concept)
 
-```bash
-# Run performance benchmarks
-./tests/generate_metrics.sh
+```
+Process (example):
+1) Prepare fixtures
+2) Run correction pipeline on short vs long inputs
+3) Collect timings and accuracy metrics
 
-# Results stored in metrics.json
+Illustrative results:
 {
   "avgCorrectionTime": 142,
   "errorReduction": 75,
@@ -313,17 +318,17 @@ tests/
 
 ## Deployment Architecture
 
-### Standalone JAR
+### Example Packaging Layout (Concept)
 
 ```
-voxcompose-0.3.0-all.jar
+voxcompose-<version>-all.jar (example)
 ├── Application classes
 ├── Dependencies (shaded)
 ├── Resources
 └── Manifest
 ```
 
-### System Requirements
+### Example System Requirements (Concept)
 
 - **Java**: 17+ (OpenJDK or Oracle)
 - **Memory**: 512MB minimum
@@ -357,4 +362,4 @@ VoxCompose's architecture prioritizes performance, privacy, and extensibility. T
 
 ---
 
-*Architecture documented for VoxCompose v0.3.0*
+*Conceptual architecture reference (examples and versions are illustrative)*

--- a/docs/LONG_TERM_CLI_INTEGRATION.md
+++ b/docs/LONG_TERM_CLI_INTEGRATION.md
@@ -1,5 +1,8 @@
 # VoxCompose Long-Term CLI Integration Plan
 
+> Conceptual Reference
+> This plan outlines a potential future CLI. This repository is documentation-only and does not include an implementation.
+
 Status: Draft
 Author: VoxCompose maintainers
 Date: 2025-09-18

--- a/docs/MACOS_PTT_INTEGRATION.md
+++ b/docs/MACOS_PTT_INTEGRATION.md
@@ -1,24 +1,25 @@
 # macOS PTT Dictation Integration Guide
 
+> Conceptual Reference
+> This repository is documentation-only. The commands and Lua examples in this guide illustrate a potential integration and are not runnable from this repository.
+
 ## Overview
 VoxCompose now supports duration-aware refinement, allowing macos-ptt-dictation to optimize when LLM refinement is triggered based on audio duration.
 
 ## Key Features
 
 ### 1. Duration Threshold Support
-VoxCompose can now receive audio duration and skip LLM refinement for short clips:
-```bash
-# Short clip (10s) - only corrections applied, no LLM
-echo "transcript" | java -jar voxcompose.jar --duration 10
-
-# Long clip (30s) - full LLM refinement
-echo "transcript" | java -jar voxcompose.jar --duration 30
+VoxCompose (concept) can receive audio duration and skip LLM refinement for short clips:
+```
+# Example (concept):
+echo "transcript" | voxcompose --duration 10
+echo "long transcript" | voxcompose --duration 30
 ```
 
 ### 2. Capabilities Negotiation
-Query VoxCompose for its current settings:
-```bash
-java -jar voxcompose.jar --capabilities
+Query VoxCompose for its current settings (concept):
+```
+voxcompose --capabilities
 ```
 
 Returns:
@@ -41,14 +42,14 @@ VoxCompose learns from refinements and applies corrections even when LLM is skip
 
 ## Integration in ptt_config.lua
 
-Update your Hammerspoon configuration to pass duration:
+Update your Hammerspoon configuration to pass duration (concept):
 
 ```lua
 -- In macos-ptt-dictation/hammerspoon/ptt_config.lua
 
 -- Query VoxCompose capabilities on startup
 function getVoxComposeCapabilities()
-    local handle = io.popen("java -jar " .. VOXCOMPOSE_JAR .. " --capabilities 2>/dev/null")
+    local handle = io.popen("/usr/local/bin/voxcompose --capabilities 2>/dev/null")
     local result = handle:read("*a")
     handle:close()
     
@@ -65,11 +66,7 @@ end
 
 -- When calling VoxCompose, pass the duration
 function refineTranscript(text, duration_seconds)
-    local cmd = {
-        "/usr/bin/java", "-jar", VOXCOMPOSE_JAR,
-        "--model", "llama3.1",
-        "--duration", tostring(math.floor(duration_seconds))  -- Add duration
-    }
+    local cmd = { "/usr/local/bin/voxcompose", "--duration", tostring(math.floor(duration_seconds)) }
     
     -- VoxCompose will automatically decide whether to use LLM
     -- based on duration and learned patterns
@@ -94,18 +91,11 @@ end
 
 Test the integration with different durations:
 
-```bash
-# Test short clip (corrections only)
-echo "i wanna pushto github" | java -jar voxcompose.jar --duration 10
-# Output: "I wanna push to GitHub"
-
-# Test long clip (full refinement)
-echo "long transcript here..." | java -jar voxcompose.jar --duration 30
-# Output: Fully refined markdown
-
-# Check current threshold
-java -jar voxcompose.jar --capabilities | jq '.activation.long_form.min_duration'
-# Output: 21
+```
+# Examples (concept)
+echo "i wanna pushto github" | voxcompose --duration 10
+echo "long transcript here..." | voxcompose --duration 30
+voxcompose --capabilities | jq '.activation.long_form.min_duration'
 ```
 
 ### Monitoring & Debugging

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,8 +1,11 @@
 # VoxCompose Performance Improvements
 
+> Conceptual Reference
+> This document presents example performance narratives and metrics for discussion. This repository is documentation-only and does not include a runnable CLI; numbers below are illustrative.
+
 ## Executive Summary
 
-VoxCompose v0.3.0 introduces revolutionary performance improvements that reduce processing time by **92%** for short inputs while maintaining **100% accuracy** on technical corrections. These improvements make real-time transcription refinement practical for daily use.
+Example performance improvements reduce processing time by up to **92%** for short inputs while maintaining high accuracy on technical corrections. These examples show how real-time transcription refinement could be made practical.
 
 ## Key Achievements
 
@@ -190,4 +193,4 @@ These improvements make VoxCompose the fastest, most accurate local transcriptio
 
 ---
 
-*Performance metrics validated on 2025-09-16 using VoxCompose v0.3.0*
+*Example metrics for illustration (2025-09-16); not from a shipped product*

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,50 @@
+# VoxCompose Release Guide
+
+This document explains how to cut a tagged release that produces a fat JAR artifact and (optionally) a Homebrew formula update.
+
+Scope
+- Output: voxcompose-cli-all.jar attached to the GitHub Release
+- Trigger: pushing a tag matching v*
+- CI: .github/workflows/release.yml
+
+Prerequisites
+- PRs merged to main (no merge commits)
+- CI green on main (Integration Tests + Java CLI)
+
+Steps
+1) Decide version bump (semver)
+- First CLI release: v0.4.0
+- Pre-release candidates: v0.4.0-rc.1, etc.
+
+2) Tag and push
+- Ensure main is up-to-date locally
+- Tag and push (example):
+
+```bash
+# from repo root on main
+NEW_TAG=v0.4.0
+git tag -a "$NEW_TAG" -m "VoxCompose CLI $NEW_TAG"
+git push origin "$NEW_TAG"
+```
+
+3) CI builds and publishes
+- Release workflow runs:
+  - Builds fat JAR: cli-java/build/libs/voxcompose-cli-all.jar
+  - Attaches artifact to the GitHub Release for the tag
+
+4) (Optional) Homebrew formula update
+- After the release is published, compute sha256 and update your tap formula:
+
+```bash
+ASSET_URL="https://github.com/cliffmin/voxcompose/releases/download/$NEW_TAG/voxcompose-cli-all.jar"
+SHA256=$(curl -L "$ASSET_URL" | shasum -a 256 | awk '{print $1}')
+# Update your tap formula with url and sha256
+```
+
+Notes
+- No root-level build files are introduced; all build artifacts and gradle config live under cli-java/
+- The fat JAR contains all dependencies and can be run with:
+
+```bash
+echo "text" | java -jar voxcompose-cli-all.jar --stats
+```

--- a/docs/SELF_LEARNING.md
+++ b/docs/SELF_LEARNING.md
@@ -1,5 +1,8 @@
 # VoxCompose Self-Learning System
 
+> Conceptual Reference
+> This repository is documentation-only. The examples and commands shown here are illustrative of a potential implementation and are not runnable from this repository.
+
 ## Overview
 
 VoxCompose's self-learning system represents a breakthrough in transcription accuracy, automatically learning from your speech patterns and vocabulary to deliver personalized, instant corrections without requiring cloud services or manual configuration.
@@ -210,33 +213,28 @@ Automatically adapts to your field:
 - **Technical**: Learns programming vocabulary
 - **Business**: Learns corporate jargon
 
-### 3. Multi-User Profiles
+### 3. Multi-User Profiles (Concept)
 
-Support for multiple users on the same machine:
-```bash
-# Switch profiles
-export VOX_PROFILE=work
-voxcompose # Uses work profile
-
-export VOX_PROFILE=personal  
-voxcompose # Uses personal profile
+Illustrative example of how a future CLI might switch profiles:
+```
+# Switch profiles (example)
+VOX_PROFILE=work   voxcompose
+VOX_PROFILE=personal  voxcompose
 ```
 
 ## Configuration
 
-### View Learning Statistics
+### View Learning Statistics (Concept)
 
-```bash
-java -jar voxcompose.jar --show-stats
-
-# Output:
+Illustrative output a future CLI could emit:
+```
 Corrections learned: 247
 Accuracy improvement: 75%
 Profile age: 14 days
 Most common corrections:
-  - pushto → push to (42 times)
-  - github → GitHub (38 times)
-  - json → JSON (31 times)
+  - pushto → push to (42)
+  - github → GitHub (38)
+  - json → JSON (31)
 ```
 
 ### Reset Learning
@@ -359,4 +357,4 @@ The result is a transcription refinement system that gets better every time you 
 
 ---
 
-*Self-learning metrics validated on 2025-09-16 using VoxCompose v0.3.0*
+*Example self-learning metrics for illustration (2025-09-16)*

--- a/docs/generate_performance_charts.sh
+++ b/docs/generate_performance_charts.sh
@@ -122,10 +122,10 @@ Test Suite: ./tests/run_tests.sh
 ├─ Error Reduction Validation:    PASS (75% fewer errors)
 └─ Throughput Test:              PASS (>1,200 words/sec)
 
-Generated: 2025-09-16
-Version: VoxCompose v0.3.0
-Hardware: MacBook Pro M1
-Dataset: 1,000 real-world transcriptions
+Generated: 2025-09-16 (example)
+Version: VoxCompose (Concept)
+Hardware: Example hardware profile
+Dataset: Example dataset description
 
 ================================================================================
 EOF

--- a/internal/CLI_MIGRATION_BEFORE_AFTER.md
+++ b/internal/CLI_MIGRATION_BEFORE_AFTER.md
@@ -1,0 +1,66 @@
+# VoxCompose CLI Migration: Before → After (Internal)
+
+Owner: VoxCompose maintainers  
+Status: Draft (kept internal)
+
+Purpose
+- Explain the transition from bash+Python helper to Gradle-based Java CLI
+- Capture the calling contract, data paths, and operational impact
+- Provide concise diagrams and rollout guidance
+
+Scope
+- macOS PTT/Hammerspoon callers and other local scripts
+- Learning data semantics (learned_profile.json) only; no LLM yet
+
+High-level evolution
+
+Before (Shim + Python)
+```
+PTT/Hammerspoon ── pipe ──> cli/voxcompose (bash) ── tee ──> tools/learn_from_text.py
+                                  │
+                                  └─ stdout (pass-through transcript)
+
+Data dir precedence handled in Python:
+VOXCOMPOSE_DATA_DIR > XDG_DATA_HOME/voxcompose > ~/Library/Application Support/VoxCompose > ~/.local/share/voxcompose
+```
+
+After (Java CLI)
+```
+PTT/Hammerspoon ── pipe ──> cli-java (java -jar voxcompose-cli*.jar)
+                                  │
+                                  ├─ stdout (pass-through transcript)
+                                  └─ learned_profile.json (atomic write)
+
+Data dir precedence handled in Java:
+VOXCOMPOSE_DATA_DIR > XDG_DATA_HOME/voxcompose > ~/Library/Application Support/VoxCompose > ~/.local/share/voxcompose
+```
+
+Contract: unchanged I/O, stable flags
+- Input: transcript via stdin
+- Output: transcript via stdout (unchanged for now)
+- Flags: --duration, --data-dir, --state-dir (reserved), --learn on|off, --dry-run, --stats
+- Behavior: when learn=on and not dry-run, update learned_profile.json with essential caps and word splits
+
+Why this migration
+- Stability: single, versioned, testable entry point
+- Reproducibility: CI builds and unit tests for the CLI
+- Packaging: fat JAR + Homebrew path, consistent installation for users
+- Separation of concerns: shim can remain thin or be replaced later
+
+Operational notes
+- No behavior change unless callers switch to Java CLI
+- Uses atomic writes for learned_profile.json
+- Data dir resolution matches docs and Python tool
+- JVM startup overhead acceptable; native image can be explored later
+
+Rollout plan (concise)
+1) Land CLI PR (rebase/squash merge; no merge commits)
+2) Tag pre-release (v0.4.0-rc.1) → CI builds fat JAR and attaches to Release
+3) Optionally publish Homebrew formula from a tap repo
+4) Switch PTT/Hammerspoon pipe to call the Java CLI (wrapper if needed)
+5) Monitor logs; add diagnostics flag later if required
+
+Open questions
+- Do we want a GraalVM native binary for ultra-fast startup?
+- Should state-dir be used for diagnostics/metrics?
+- When to deprecate the bash shim once adoption is stable?

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "voxcompose",
+  "version": "0.0.0",
+  "private": true
+}


### PR DESCRIPTION
This PR introduces the initial Java CLI (Gradle) and CI:

- New: cli-java/ Gradle module (Java 17)
  - Main: stdin→stdout pass-through with optional learning and stats
  - DataDirResolver: VOXCOMPOSE_DATA_DIR > XDG_DATA_HOME/voxcompose > macOS App Support > Linux ~/.local/share
  - MinimalLearner: mirrors Python helper (caps + splits) and updates vocabulary
  - ProfileIO: Jackson load/save with atomic writes
  - Unit tests (JUnit 5): learner + resolver
- CI:
  - Java CLI workflow (java.yml): builds and runs tests under cli-java
  - Integration Tests workflow (integration-tests.yml): retains required check name and runs tests/run_tests.sh

Notes:
- Complies with repository rules: changes via PR, no merge commits expected
- Adds the required "Integration Tests" workflow name to satisfy protected branch checks
