### PR TITLE
ci: add concurrency and skip heavy jobs for docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,13 +3,33 @@ on:
   pull_request:
   push:
     branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Determine changed paths
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            docs_only:
+              - '**/*.md'
+              - 'docs/**'
+
       - name: Run test suite
+        if: ${{ steps.changes.outputs.docs_only != 'true' }}
         shell: bash
         run: |
           chmod +x tests/run_tests.sh
           bash tests/run_tests.sh
+
+      - name: Skip heavy tests for docs-only changes
+        if: ${{ steps.changes.outputs.docs_only == 'true' }}
+        run: echo "Docs-only changes detected; skipping tests."

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,17 @@ name: Docs
 on:
   push:
     branches: [ main ]
+    paths:
+      - '**/*.md'
+      - 'docs/**'
   pull_request:
+    paths:
+      - '**/*.md'
+      - 'docs/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   links:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -5,12 +5,31 @@ on:
     branches: [ main ]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   integration:
     name: Integration Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Determine changed paths
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            docs_only:
+              - '**/*.md'
+              - 'docs/**'
+
       - name: Run integration tests
+        if: ${{ steps.changes.outputs.docs_only != 'true' }}
         run: |
           bash tests/run_tests.sh
+
+      - name: Skip integration tests for docs-only changes
+        if: ${{ steps.changes.outputs.docs_only == 'true' }}
+        run: echo "Docs-only changes detected; skipping integration tests."

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -5,24 +5,47 @@ on:
     branches: [ main ]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Java CLI
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Determine changed paths
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            docs_only:
+              - '**/*.md'
+              - 'docs/**'
+
       - name: Set up JDK 17
+        if: ${{ steps.changes.outputs.docs_only != 'true' }}
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: '17'
+
       - name: Install Gradle via SDKMAN
+        if: ${{ steps.changes.outputs.docs_only != 'true' }}
         run: |
           curl -s "https://get.sdkman.io" | bash
           source "$HOME/.sdkman/bin/sdkman-init.sh"
           sdk install gradle 8.7
           gradle -v
+
       - name: Build and Test (cli-java)
+        if: ${{ steps.changes.outputs.docs_only != 'true' }}
         run: |
           source "$HOME/.sdkman/bin/sdkman-init.sh"
           gradle -p cli-java test --no-daemon --stacktrace
+
+      - name: Skip heavy Java build for docs-only PR
+        if: ${{ steps.changes.outputs.docs_only == 'true' }}
+        run: echo "Docs-only changes detected; skipping Java build/tests."


### PR DESCRIPTION
- Add concurrency (cancel-in-progress) to all workflows\n- In Java CLI/tests/integration workflows, detect docs-only changes with dorny/paths-filter and skip heavy steps while keeping required checks green\n- Restrict Docs workflow to only docs/ and Markdown paths\n\nRequired check names remain unchanged (links, hygiene, Java CLI, tests, Integration Tests).