### PR TITLE
ci: introduce standardized check names (Quick Validation, Quality Checks, Java Compilation, Java Tests)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,10 @@ on:
     branches: [ main ]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   links:
     runs-on: ubuntu-latest
@@ -30,3 +34,19 @@ jobs:
           test ! -d src || (echo "src/ should not exist" && exit 1)
           test ! -d packaging || (echo "packaging/ should not exist" && exit 1)
           test ! -d bin || (echo "bin/ should not exist" && exit 1)
+
+  quick_validation:
+    name: Quick Validation
+    runs-on: ubuntu-latest
+    needs: [links, hygiene]
+    steps:
+      - name: Quick validation passed
+        run: echo "Links and hygiene checks completed"
+
+  quality_checks:
+    name: Quality Checks
+    runs-on: ubuntu-latest
+    needs: [hygiene]
+    steps:
+      - name: Quality checks passed
+        run: echo "Hygiene checks completed"

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -5,24 +5,85 @@ on:
     branches: [ main ]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  build:
-    name: Java CLI
+  compile:
+    name: Java Compilation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Determine changed paths
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            docs_only:
+              - '**/*.md'
+              - 'docs/**'
       - name: Set up JDK 17
+        if: ${{ steps.changes.outputs.docs_only != 'true' }}
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: '17'
       - name: Install Gradle via SDKMAN
+        if: ${{ steps.changes.outputs.docs_only != 'true' }}
         run: |
           curl -s "https://get.sdkman.io" | bash
           source "$HOME/.sdkman/bin/sdkman-init.sh"
           sdk install gradle 8.7
           gradle -v
-      - name: Build and Test (cli-java)
+      - name: Compile (cli-java)
+        if: ${{ steps.changes.outputs.docs_only != 'true' }}
+        run: |
+          source "$HOME/.sdkman/bin/sdkman-init.sh"
+          gradle -p cli-java compileJava --no-daemon --stacktrace
+      - name: Skip compilation for docs-only changes
+        if: ${{ steps.changes.outputs.docs_only == 'true' }}
+        run: echo "Docs-only changes detected; skipping Java compilation."
+
+  java_tests:
+    name: Java Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Determine changed paths
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            docs_only:
+              - '**/*.md'
+              - 'docs/**'
+      - name: Set up JDK 17
+        if: ${{ steps.changes.outputs.docs_only != 'true' }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Install Gradle via SDKMAN
+        if: ${{ steps.changes.outputs.docs_only != 'true' }}
+        run: |
+          curl -s "https://get.sdkman.io" | bash
+          source "$HOME/.sdkman/bin/sdkman-init.sh"
+          sdk install gradle 8.7
+          gradle -v
+      - name: Run Tests (cli-java)
+        if: ${{ steps.changes.outputs.docs_only != 'true' }}
         run: |
           source "$HOME/.sdkman/bin/sdkman-init.sh"
           gradle -p cli-java test --no-daemon --stacktrace
+      - name: Skip tests for docs-only changes
+        if: ${{ steps.changes.outputs.docs_only == 'true' }}
+        run: echo "Docs-only changes detected; skipping Java tests."
+
+  build:
+    name: Java CLI
+    runs-on: ubuntu-latest
+    needs: [compile, java_tests]
+    steps:
+      - name: Aggregated Java checks passed
+        run: echo "Compilation and tests completed."


### PR DESCRIPTION
Transitional PR to introduce standardized required check names without breaking branch protection.\n\n- Docs workflow: add jobs\n  - Quick Validation (needs: links, hygiene)\n  - Quality Checks (needs: hygiene)\n- Java workflow: add jobs\n  - Java Compilation (compilation only)\n  - Java Tests (tests only)\n  - Keep Java CLI job as an aggregator (needs both), no heavy steps\n- Add concurrency blocks\n\nAfter this merges, we can update branch protection to require only: Quick Validation, Java Compilation, Java Tests, Quality Checks; then in a follow-up PR remove the legacy check jobs if desired.
