### PR TITLE
chore: prepare v1.0.0 release

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "dev.voxcompose"
-version = "0.4.4"
+version = "1.0.0"
 
 java {
   toolchain { languageVersion.set(JavaLanguageVersion.of(21)) }


### PR DESCRIPTION
## Summary

- Bump version from 0.4.4 to 1.0.0 in build.gradle.kts

## Context

The v1.0.0 features (self-learning corrections, duration-aware processing, vocabulary export) have been on main since 2025-10-13 per the CHANGELOG, but the version in build.gradle.kts was never bumped. This aligns the build version with the documented release.

After merge, tag `v1.0.0` will trigger the release workflow to build the fat JAR and create the GitHub Release.

## Test plan

- [ ] CI passes
- [ ] After merge: tag v1.0.0, verify release workflow produces JAR artifact
- [ ] After release: update homebrew-tap formula with new JAR URL and SHA256

Made with [Cursor](https://cursor.com)